### PR TITLE
Fix file pattern in gemspec for directories

### DIFF
--- a/esphome.gemspec
+++ b/esphome.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files = Dir["{exe|lib}/**/*"]
+  spec.files = Dir["{exe,lib}/**/*"]
   spec.bindir = "exe"
   spec.executables = ["esphome-monitor"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Currently only the exe/esphome-monitor is included in the gem file